### PR TITLE
Update Vite base path for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/', // Important for GitHub Pages root domain
+  base: '/Parth-G-Bambhaniya.github.io/', // 👈 Add this line
 })


### PR DESCRIPTION
Changed the Vite config 'base' option to '/Parth-G-Bambhaniya.github.io/' to ensure correct asset paths when deploying to GitHub Pages.